### PR TITLE
feat: add profile alerts and metrics

### DIFF
--- a/src/components/TokenTransferModal/TokenTransferModal.tsx
+++ b/src/components/TokenTransferModal/TokenTransferModal.tsx
@@ -3,6 +3,7 @@ import { PublicKey } from "@solana/web3.js";
 import { SupersizeVaultClient } from "@engine/SupersizeVaultClient";
 import { MagicBlockEngine } from "@engine/MagicBlockEngine";
 import "./Modal.css";
+import NotificationService from "@components/notification/NotificationService";
 
 type Props = {
   engine: MagicBlockEngine;
@@ -51,6 +52,11 @@ const TokenTransferModal: React.FC<Props> = ({
     if (value === 0 || isProcessing) return;
 
     setIsProcessing(true);
+    const alertId = NotificationService.addAlert({
+      type: "success",
+      message: `submitting ${kind}...`,
+      shouldExit: false,
+    });
     try {
       if (kind === "deposit") {
         await vaultClient.deposit(new PublicKey(token.mint), value);
@@ -60,8 +66,16 @@ const TokenTransferModal: React.FC<Props> = ({
       }
     } catch (error) {
       console.error(`Failed to ${kind}:`, error);
-      alert(`The ${kind} transaction failed.`);
+      const exitAlertId = NotificationService.addAlert({
+        type: "error",
+        message: `${kind} failed`,
+        shouldExit: false,
+      });
+      setTimeout(() => {
+        NotificationService.updateAlert(exitAlertId, { shouldExit: true });
+      }, 3000);
     } finally {
+      NotificationService.updateAlert(alertId, { shouldExit: true });
       setIsProcessing(false);
     }
   };

--- a/src/components/util/Graph.tsx
+++ b/src/components/util/Graph.tsx
@@ -1,8 +1,8 @@
-import React, { useState, useEffect } from "react";
-import { Line } from "react-chartjs-2";
+import React, { useEffect, useState } from "react";
+import { Bar } from "react-chartjs-2";
 import {
   Chart as ChartJS,
-  LineElement,
+  BarElement,
   CategoryScale,
   LinearScale,
   Tooltip,
@@ -10,8 +10,9 @@ import {
 } from "chart.js";
 import { MagicBlockEngine } from "../../engine/MagicBlockEngine";
 import { PublicKey } from "@solana/web3.js";
+import { countTransactionsByDay } from "@states/adminFunctions";
 
-ChartJS.register(LineElement, CategoryScale, LinearScale, Tooltip, Legend);
+ChartJS.register(BarElement, CategoryScale, LinearScale, Tooltip, Legend);
 
 interface GraphProps {
   engine: MagicBlockEngine;
@@ -20,92 +21,43 @@ interface GraphProps {
 
 const Graph: React.FC<GraphProps> = ({ engine, mapComponentPda }) => {
   const [chartData, setChartData] = useState<any>(null);
-  const [chartReady, setChartReady] = useState(false);
 
   useEffect(() => {
-    setTimeout(() => {
-      const values = Array.from({ length: 30 }, (_, i) => i);
-
-      
-      const data = {
-        labels: values,
+    const fetchData = async () => {
+      const counts = await countTransactionsByDay(engine, mapComponentPda);
+      const labels = Array.from({ length: 7 }).map((_, i) => {
+        const d = new Date();
+        d.setDate(d.getDate() - (6 - i));
+        return `${d.getMonth() + 1}/${d.getDate()}`;
+      });
+      setChartData({
+        labels,
         datasets: [
           {
-            label: "Food value multiplier",
-            data: values,
-            borderColor: "rgba(75,192,192,1)",
-            borderWidth: 2,
-            fill: false,
-            tension: 0.4,
-            z: 1,
-          },
-          {
-            label: "Current Value",
-            data: values,
-            borderColor: "rgba(255,0,0,1)",
-            borderWidth: 3,
-            pointRadius: 8,
-            pointBackgroundColor: "rgba(255,0,0,1)",
-            showLine: false,
-            z: 2,
+            label: "Players per day",
+            data: counts,
+            backgroundColor: "rgba(75,192,192,0.5)",
           },
         ],
-      };
-
-      setChartData(data);
-    }, 0);
+      });
+    };
+    fetchData();
   }, [engine, mapComponentPda]);
 
   const options = {
     responsive: true,
-    animation: {
-      duration: 1000,
-      onComplete: () => setChartReady(true),
-    },
     plugins: {
       legend: { position: "top" as const },
       tooltip: { enabled: true },
-      decimation: {
-        enabled: true,
-        algorithm: "lttb" as const, 
-        samples: 500,
-      },
-    },
-    scales: {
-      x: {
-        title: { display: true, text: "tokens in wallet" },
-      },
-      y: {
-        title: { display: true, text: "food value multiplier" },
-        min: 0.5,
-        max: chartData ? Math.max(...chartData.datasets[0].data) : undefined,
-      },
     },
   };
 
   return (
-    <div style={{ width: "600px", margin: "0 auto", position: "relative" }}>
+    <div style={{ width: "600px", margin: "0 auto" }}>
       {chartData ? (
-        <Line data={chartData} options={options} />
+        <Bar data={chartData} options={options} />
       ) : (
         <div style={{ textAlign: "center", padding: "50px" }}>Loading data...</div>
-      )}
-      {chartData && !chartReady && (
-        <div
-          style={{
-            position: "absolute",
-            top: 0,
-            left: 0,
-            width: "100%",
-            height: "100%",
-            display: "flex",
-            justifyContent: "center",
-            alignItems: "center",
-            background: "rgba(255,255,255,0.8)",
-          }}
-        >
-          Loading chart...
-        </div>
       )}
     </div>
   );


### PR DESCRIPTION
## Summary
- add notification container and alerts for wallet and admin transactions
- fix admin panel data loading by waiting for endpoint setup
- add User Metrics bar chart for recent player activity

## Testing
- `npm run lint` *(fails: many existing lint errors)*
- `npm test -- --watchAll=false` *(fails: no tests found)*

------
https://chatgpt.com/codex/tasks/task_e_689088cae73c8328b537065884b5db3b